### PR TITLE
Add AURA routing to part of the Internal MtA Rail

### DIFF
--- a/data/Lines/hits.toml
+++ b/data/Lines/hits.toml
@@ -9,6 +9,7 @@ links = [
 #    "hits-lusitania_crossing",
     "hits-lumiere_crossing",
     "hits-christmas_crossing",
+    "hits-mta_crossing",
     "little_leningrad_crossing",
     "westminster",
 #    "airhaven",

--- a/data/Lines/mta_internal.toml
+++ b/data/Lines/mta_internal.toml
@@ -1,0 +1,19 @@
+# A line connecting the HITS/Mta Station to the Nexus-SW rail
+name = "Internal MtA rail"
+
+type = "line"
+dest_a = "mta:west"
+dest_b = "mta:east"
+
+links = [
+    "hits-mta_crossing",
+    "mta-farms_crossing",
+    "mta-sa_crossing",
+    "mta-mush_crossing",
+    "mta-walton_crossing"
+    # MtS Crossing
+    # Canopus
+    # MTA Nether
+    # Doom Island
+    # Nexus Crossing
+]

--- a/data/Stations/mount_september.toml
+++ b/data/Stations/mount_september.toml
@@ -14,17 +14,13 @@ z = 2215
 links = [
 "csr",
 "hits-christmas_crossing",
-"mta_internal",
+"mta-walton_crossing",
 "gabon"
-]
-
-unsafe_links = [
-"south_augusta"
 ]
 
 [link_dests]
 hits-christmas_crossing = "sept:hits"
-mta_internal = "sept:mta"
+mta-walton_crossing = "sept:mta"
 
 [bad_links]
 gabon = "gabon" # pending adding new entries to switches

--- a/data/Stations/mount_september.toml
+++ b/data/Stations/mount_september.toml
@@ -18,6 +18,11 @@ links = [
 "gabon"
 ]
 
+
+unsafe_links = [
+"mta-walton_crossing" # result of mts station design and south augusta's lack of an AURA specific dest
+]
+
 [link_dests]
 hits-christmas_crossing = "sept:hits"
 mta-walton_crossing = "sept:mta"

--- a/data/Stations/mount_september.toml
+++ b/data/Stations/mount_september.toml
@@ -14,7 +14,7 @@ z = 2215
 links = [
 "csr",
 "hits-christmas_crossing",
-"south_augusta",
+"mta_internal",
 "gabon"
 ]
 
@@ -24,6 +24,7 @@ unsafe_links = [
 
 [link_dests]
 hits-christmas_crossing = "sept:hits"
+mta_internal = "sept:mta"
 
 [bad_links]
 gabon = "gabon" # pending adding new entries to switches

--- a/data/Stations/mta_farms.toml
+++ b/data/Stations/mta_farms.toml
@@ -1,0 +1,11 @@
+# The Mta MegaFarms
+name = "MTA Farms"
+
+type = "stop"
+dest = "megafarms"
+
+x = -6175
+z = 2950
+
+links = ["mta-farms_crossing"]
+station = true

--- a/data/Stations/mta_mushroom.toml
+++ b/data/Stations/mta_mushroom.toml
@@ -1,0 +1,11 @@
+# The Mta Mushroom Island, also known as Spartly Island
+name = ["Spartly Island","MTA Mushroom"]
+
+type = "stop"
+dest = "mta_mushroom"
+
+x = -5906
+z = 3250
+
+links = ["mta-mush_crossing"]
+station = true

--- a/data/Stations/south_augusta.toml
+++ b/data/Stations/south_augusta.toml
@@ -8,7 +8,7 @@ x = -6041
 z = 3775
 
 links = [
-    "mta_internal",
+    "mta-sa_crossing",
     "gor",
     "wesbury"
 ]

--- a/data/Stations/south_augusta.toml
+++ b/data/Stations/south_augusta.toml
@@ -8,7 +8,7 @@ x = -6041
 z = 3775
 
 links = [
-    "mount_september",
+    "mta_internal",
     "gor",
     "wesbury"
 ]
@@ -18,3 +18,4 @@ surface = true
 
 [link_dests]
 gor = "gor"
+mta_internal = "sa:north"

--- a/data/Stations/walton.toml
+++ b/data/Stations/walton.toml
@@ -1,0 +1,10 @@
+name = ["Walton"]
+
+type = "stop"
+dest = "walton"
+
+x = -5550
+z = 2700
+
+links = ["mta-walton_crossing"]
+station = true

--- a/data/Switches/hits-mta_crossing.toml
+++ b/data/Switches/hits-mta_crossing.toml
@@ -1,0 +1,6 @@
+type = "crossing"
+
+x = -6700
+z = 3000
+
+links = ["hits","mta_internal"]

--- a/data/Switches/mta-farms_crossing.toml
+++ b/data/Switches/mta-farms_crossing.toml
@@ -1,0 +1,11 @@
+# A 4-way crossing including an unfinished rail to sealand
+type = "crossing"
+
+x = -6175
+z = 3000
+
+links = [
+    "mta_internal",
+    "mta_farms",
+#    "sealand"
+]

--- a/data/Switches/mta-mush_crossing.toml
+++ b/data/Switches/mta-mush_crossing.toml
@@ -1,0 +1,9 @@
+type = "crossing"
+
+x = -5906
+z = 3000
+
+links = [
+    "mta_internal",
+    "mta_mushroom"
+]

--- a/data/Switches/mta-sa_crossing.toml
+++ b/data/Switches/mta-sa_crossing.toml
@@ -1,0 +1,9 @@
+type = "crossing"
+
+x = -6041
+z = 3000
+
+links = [
+    "mta_internal",
+    "south_augusta"
+]

--- a/data/Switches/mta-walton_crossing.toml
+++ b/data/Switches/mta-walton_crossing.toml
@@ -1,0 +1,10 @@
+type = "crossing"
+
+x = -5700
+z = 3000
+
+links = [
+    "mta_internal",
+    "walton",
+    "mount_september"
+]


### PR DESCRIPTION
The internal MtA rail is a line that branches east from the hits at z=3000 and continues until the Nexus-Westminster rail

Dests are mta:west and mta:east

All points between the hits and the walton/mts crossing are supported:
* MtA farms
* South Augusta
* Spratly Island
* Walton/MtS crossing

This means that stations and crossings east of these are currently unsupported (Canopus/MtA Nether/Laconia Doom Island, etc)