### PR TITLE
Temporary fix for Westminster being KANI compliant

### DIFF
--- a/data/Stations/westminster.toml
+++ b/data/Stations/westminster.toml
@@ -2,7 +2,7 @@ name = ["Westminster","Commonwealth","CW"]
 x = -7120
 z = 5099
 
-type = "stop"
+type = "junctionstop"
 dest = "westminster"
 
 links = [


### PR DESCRIPTION
Needs an :exit clause as a final command